### PR TITLE
Timeout doesn't display saved console.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Upload Executable
       if: startsWith(github.ref, 'refs/tags/')
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: HercControl-Ubuntu
         path: "${{ runner.temp }}/exe"
@@ -109,7 +109,7 @@ jobs:
 
     - name: Upload Executable
       if: startsWith(github.ref, 'refs/tags/')
-      uses: actions/upload-artifact@v1
+      uses: actions/upload-artifact@v4
       with:
         name: HercControl-Windows
         path: "${{ runner.temp }}/exe"
@@ -155,7 +155,7 @@ jobs:
 
       - name: Upload Executable
         if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: HercControl-MacOS
           path: "${{ runner.temp }}/exe"
@@ -170,7 +170,7 @@ jobs:
       - uses: actions/checkout@v1
 
       - name: Get ubuntu binary 
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: HercControl-Ubuntu
 
@@ -179,7 +179,7 @@ jobs:
           zip -r HercControl-Ubuntu.zip HercControl-Ubuntu
 
       - name: Get windows binary 
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: HercControl-Windows
 
@@ -188,7 +188,7 @@ jobs:
           zip -r HercControl-Windows.zip HercControl-Windows
 
       - name: Get macos binary
-        uses: actions/download-artifact@v1
+        uses: actions/download-artifact@v4
         with:
           name: HercControl-MacOS
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -11,7 +11,7 @@ jobs:
 
     services:
       vm370:
-        image: adriansutherland/vm370:latest
+        image: rosspatterson/vm370:latest
         ports:
           - 8038:8038
 

--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -173,6 +173,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: HercControl-Ubuntu
+          path: HercControl-Ubuntu
 
       - name: ZIP ubuntu binary 
         run: 
@@ -182,6 +183,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: HercControl-Windows
+          path: HercControl-Windows
 
       - name: ZIP windows binary 
         run: 
@@ -191,6 +193,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: HercControl-MacOS
+          path: HercControl-MacOS
 
       - name: ZIP macos binary
         run:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 cmake_policy(SET CMP0091 NEW)
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
 
-project(HercControl VERSION 1.1.1)
+project(HercControl VERSION 1.1.2)
 
 #include(CTest)
 #enable_testing()

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,6 @@
 HercControl Change Log
 ======================
-
+Issue   00001 - Timeout doesn't display saved console.
 Feature f0102 - Control returned. Output all console, last (found line) line or silent (nothing)
 Feature f0101 - Set marker. Allows the read from point (marker) to be set so that the console can be read to get external events like mounting a tape
 Feature f0100 - Timeout logging. Show Hercules console output on timeout (helps debugging)

--- a/src/HercControl.cpp
+++ b/src/HercControl.cpp
@@ -249,6 +249,7 @@ void callHerculesConsole(string command, string waitFor, vector<string>& console
 					cerr << rang::fg::cyan << "Timeout Reset" << rang::style::reset << endl;
 			}
 		}
+		console.insert(console.begin(), saveConsole.begin(), saveConsole.end());
 		throw runtime_error("Timeout");
 	}
 }

--- a/test/basictest.cmd
+++ b/test/basictest.cmd
@@ -1,10 +1,10 @@
-.\herccontrol "ipl 141" -w "USER DSC LOGOFF AS AUTOLOG1"
+.\herccontrol "ipl 6a1" -w "USER DSC LOGOFF AS AUTOLOG1"
 if %errorlevel% NEQ 0 goto:eof
 .\herccontrol "/enable all" -w "COMMAND COMPLETE"
 if %errorlevel% NEQ 0 goto:eof
 .\herccontrol "/cp disc" -w "^VM/370 Online"
 if %errorlevel% NEQ 0 goto:eof
-.\herccontrol "/logon cmsuser cmsuser" -w "^CMS"
+.\herccontrol "/logon cmsuser cmsuser" -w "^VM Community Edition"
 if %errorlevel% NEQ 0 goto:eof
 .\herccontrol "/" -w "^Ready"
 if %errorlevel% NEQ 0 goto:eof

--- a/test/basictest.sh
+++ b/test/basictest.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
-./herccontrol "ipl 141" -w ""
+./herccontrol "ipl 6a1" -w ""
 ./herccontrol "" -w "USER DSC LOGOFF AS AUTOLOG1"
 ./herccontrol "/enable all" -w "COMMAND COMPLETE"
 ./herccontrol "/cp disc" -w "^VM/370 Online"
-./herccontrol "/logon cmsuser cmsuser" -w "^CMS"
+./herccontrol "/logon cmsuser cmsuser" -w "^VM Community Edition"
 ./herccontrol "/" -w "^Ready"
 ./herccontrol "/listf * * a" -w "^Ready"
 ./herccontrol "/logoff" -w "^VM/370 Online"


### PR DESCRIPTION
If `herccontrol` times out, a small number of lines of the console output are displayed.  The previously-collected output, in `saveConsole`, is not displayed.  These missing lines can be useful in determining the cause of the failure.

This change adds the previously-collected output to the display.

**NOTE:** The changes to  both tests, and the Docker image name in `.github/workflows/ccpp.yml`, are to switch to my VM/CE 1.1.2 image, and probably _should not_ be merged with this PR.  The rest of the `ccpp.yml` changes are to adapt to changes in GitHub' actions, and should be merged.